### PR TITLE
Added route to action that creates a dev user and logs them in.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,6 +14,23 @@ class SessionsController < ApplicationController
     flash[:success] = "Welcome, #{current_user.name}"
     redirect_to user_notes_path(current_user)
   end
+  
+  # Method to create a dummy user in the development env
+	def create_dev_session
+		# Get user name from .env file
+		username = ENV['DEV_USER']
+
+		# if user with username doesn't exist, create one
+		user = User.find_by(name: username)
+		unless user.present?
+			user = User.new(name: username)
+			user.save!
+		end
+
+		# sign in user and redirect to notes
+		session[:user_id] = user.id
+		redirect_to user_notes_path(current_user)
+	end
 
   # Method to destroy a user session
   def destroy

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,6 +17,9 @@ class SessionsController < ApplicationController
   
   # Method to create a dummy user in the development env
 	def create_dev_session
+		# redirect to root if not in dev environment
+		redirect_to root_path unless Rails.env == 'development'
+
 		# Get user name from .env file
 		username = ENV['DEV_USER']
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+  # Route for login in development environment
+	if Rails.env == 'development'
+		get '/dev_login' => 'sessions#create_dev_session'
+	end
+
   # For javascript tests
   mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
   

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 class SessionsControllerTest < ActionController::TestCase
   setup :set_omniauth
 
+  def set_omniauth
+    request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:google]
+  end
+
   test 'should successfully login user via google' do
     assert_difference('User.count', 1) do
       get :create, provider: 'google'
@@ -37,9 +41,5 @@ class SessionsControllerTest < ActionController::TestCase
 
     assert_redirected_to root_path
     assert_not_nil flash[:danger]
-  end
-
-  def set_omniauth
-    request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:google]
   end
 end


### PR DESCRIPTION
Added a route that points to an action that creates a user in the development environment and logs them in. Needs a `DEV_USER='username'` variable set in the .env file.